### PR TITLE
build-test workflow improvements

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,6 +71,16 @@ jobs:
           git push --quiet --set-upstream origin-pages gh-pages;
           echo "Updated and pushed GH pages!";
         fi
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      continue-on-error: true
+      with:
+        check_name: Unit Test Results
+        comment_mode: create new
+        fail_on: nothing
+        hide_comments: orphaned commits
+        files: |
+          **/build/test-results/**/*.xml
     - name: Publish Test Coverage Results
       if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
       uses: madrapps/jacoco-report@v1.2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,22 @@ on:
   push:
 
 jobs:
+  dupe_check:
+    name: Check for Duplicate Workflow Run
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.0
+        with:
+          concurrent_skipping: same_content
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   build:
+    needs:
+      - dupe_check
+    if: needs.dupe_check.outputs.should_skip != 'true'
 
     runs-on: ubuntu-latest
 
@@ -15,15 +30,33 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Setup JDK 1.8
-      uses: actions/setup-java@v1
+
+    - name: Cache Gradle
+      uses: actions/cache@v2
       with:
-        java-version: 1.8
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-build-test-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-build-test-
+
+    - name: Setup JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: zulu
+        java-version: 8
+
+    - name: Validate Gradle wrapper
+      uses: gradle/wrapper-validation-action@v1
+
     - name: Install Test Support
       working-directory: solace-integration-test-support
       run: ./mvnw clean install -DskipTests
+
     - name: Build and test with Gradle
       run: ./gradlew clean test integrationTest jacocoFullReport --info
+
     - name: Upload Test Artifacts
       if: always()
       uses: actions/upload-artifact@v2
@@ -33,6 +66,7 @@ jobs:
           **/build/jacoco/*.exec
           **/build/reports/
           **/build/test-results/**/*.xml
+
     - name: Publish artifacts
       if: github.event_name == 'push'
       run: |
@@ -71,6 +105,14 @@ jobs:
           git push --quiet --set-upstream origin-pages gh-pages;
           echo "Updated and pushed GH pages!";
         fi
+
+    - name: Cleanup Gradle Cache
+      # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+      # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+      run: |
+        rm -f ~/.gradle/caches/modules-2/modules-2.lock
+        rm -f ~/.gradle/caches/modules-2/gc.properties
+
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1
       continue-on-error: true
@@ -81,6 +123,7 @@ jobs:
         hide_comments: orphaned commits
         files: |
           **/build/test-results/**/*.xml
+
     - name: Publish Test Coverage Results
       if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
       uses: madrapps/jacoco-report@v1.2


### PR DESCRIPTION
* publish test results as PR comment
* add gradle wrapper validation
* add gradle caching
* skip duplication workflow runs